### PR TITLE
Update to memcachedpagecache for 5.7.5.13

### DIFF
--- a/application/src/Cache/Page/MemcachedPageCache.php
+++ b/application/src/Cache/Page/MemcachedPageCache.php
@@ -5,7 +5,7 @@ use Concrete\Core\Cache\Page\PageCache;
 use Concrete\Core\Cache\Page\PageCacheRecord;
 use Stash\Driver\Memcache;
 use Stash\Pool;
-use Page as ConcretePage;
+use Concrete\Core\Page\Page as ConcretePage;
 use Config;
 
 class MemcachedPageCache extends PageCache


### PR DESCRIPTION
The PageCache file was changed from the facade Page to the Concrete\Core\Page\Page and as such the declaration must be updated

#5 This fixes it so it will work on v5.7.5.13

For version 8 use the version 8 branch